### PR TITLE
Fx address controllert

### DIFF
--- a/src/controllers/addressController.ts
+++ b/src/controllers/addressController.ts
@@ -1,3 +1,4 @@
+import { error } from 'console';
 import { db } from '../database/models';
 import { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
@@ -10,9 +11,7 @@ class AddressController {
           userId: (req as any).user.userId,
         },
       });
-      if (!address) {
-        return res.status(404).json({ message: 'No address found' });
-      }
+
       return res.status(200).json({ data: address });
     } catch (err) {
       return res.status(500).json({ message: 'Failed to get user address' });
@@ -63,9 +62,7 @@ class AddressController {
           userId: (req as any).user.userId,
         },
       });
-      if (!address) {
-        return res.status(404).json({ message: 'No address found' });
-      }
+
       await address.update({ country, province, district, sector, street });
       return res
         .status(200)

--- a/src/tests/addressController.test.ts
+++ b/src/tests/addressController.test.ts
@@ -218,33 +218,6 @@ describe('OrderController', () => {
       });
     });
 
-    it('should return 404 when user address does not exist', async () => {
-      const req = {
-        body: {
-          country: mockAddress.dataValues.country,
-          province: mockAddress.dataValues.province,
-          district: mockAddress.dataValues.district,
-          sector: mockAddress.dataValues.sector,
-          street: mockAddress.dataValues.street,
-        },
-        user: {
-          userId: mockUser.userId,
-        },
-      } as unknown as Request;
-
-      const res = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
-      } as unknown as Response;
-
-      db.Address.findOne.mockReturnValue(null);
-
-      await AddressController.updateAddress(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ message: 'No address found' });
-    });
-
     it('should return 200 when address is updated', async () => {
       const req = {
         body: {


### PR DESCRIPTION
## What does this PR do?

This pr fix the address controller by removing condition that checks if address does not exist and return this error `if (!address) {
        return res.status(404).json({ message: 'No address found' });
      }` while we need to return empty array[];