### PR TITLE
[Fixes #187355124] Adding missing paymentIntent object on createOrder and getAllUserOrders Route and Wishlist Fixes

### DIFF
--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -46,7 +46,7 @@ class OrderController {
         quantity: quantity,
       });
 
-      return res.status(200).json({ order });
+      return res.status(200).json({ order, paymentIntent });
     } catch (error: any) {
       console.log(error);
       return res.status(500).json({ message: 'Failed to create order' });
@@ -77,6 +77,29 @@ class OrderController {
     } catch (error: any) {
       console.log(error);
       return res.status(500).json({ message: 'Failed to get orders' });
+    }
+  }
+
+  static async getAllUserOrders(req: Request, res: Response) {
+    try {
+      const orders: any = await db.Order.findAll({
+        where: {
+          userId: (req as any).user.userId,
+        },
+        include: [
+          {
+            model: db.Product,
+            through: {
+              model: db.OrderProduct,
+              attributes: ['quantity'],
+            },
+          },
+        ],
+      });
+
+      res.status(200).json({ orders });
+    } catch (err: any) {
+      return res.status(500).json({ message: 'Failed to get all user orders' });
     }
   }
 

--- a/src/controllers/wishlist.ts
+++ b/src/controllers/wishlist.ts
@@ -1,20 +1,25 @@
 import { Request, Response } from 'express';
 import { db } from '../database/models';
+
 const { Wishlist, User, Product } = db;
+
 export default class WishlistController {
   static async addToWishlist(req: Request, res: Response): Promise<Response> {
     try {
       const productId = req.params.productId;
       const userId = res.locals.userId;
+
       if (!userId) {
         return res.status(401).json({ message: 'Unauthorized' });
       }
+
       const product = await Product.findOne({
         where: { productId: productId },
       });
       if (!product) {
         return res.status(404).json({ message: 'Product not found' });
       }
+
       const existingWishlistItem = await Wishlist.findOne({
         where: { userId, productId },
       });
@@ -23,7 +28,9 @@ export default class WishlistController {
           .status(400)
           .json({ message: 'Product already in your wishlist' });
       }
+
       const wishlistItem = await Wishlist.create({ userId, productId });
+
       return res.status(201).json({
         message: 'Product added to your wishlist',
         wishlistItem,
@@ -35,6 +42,7 @@ export default class WishlistController {
       });
     }
   }
+
   static async deleteFromWishlist(
     req: Request,
     res: Response,
@@ -42,16 +50,21 @@ export default class WishlistController {
     try {
       const userId = res.locals.userId;
       const productId = req.params.productId;
+
       if (!userId || !productId) {
         return res.status(404).json({ message: 'Product ID is required' });
       }
+
       const wishlistItem = await Wishlist.findOne({
         where: { userId, productId },
       });
+
       if (!wishlistItem) {
         return res.status(404).json({ message: 'Wishlist item not found' });
       }
+
       await wishlistItem.destroy();
+
       return res
         .status(200)
         .json({ message: 'Product removed from your wishlist' });
@@ -62,34 +75,42 @@ export default class WishlistController {
       });
     }
   }
+
   static async getWishlist(req: Request, res: Response) {
     try {
       const userId = res.locals.userId;
+
       const wishlists = await Wishlist.findAll({
         where: { userId },
         include: [
           {
             model: Product,
             as: 'product',
-            attributes: ['name', 'price'],
+            attributes: ['name', 'price', 'images'],
           },
         ],
       });
+
       if (!wishlists.length) {
         return res.status(200).json([]);
       }
+
       return res.status(200).json(wishlists);
     } catch (error: any) {
       return res.status(500).json({ error: error.message });
     }
   }
+
   static async clearWishlist(req: Request, res: Response): Promise<Response> {
     try {
       const userId = res.locals.userId;
+
       if (!userId) {
         return res.status(401).json({ message: 'Unauthorized' });
       }
+
       await Wishlist.destroy({ where: { userId } });
+
       return res.status(200).json({ message: 'Wishlist cleared successfully' });
     } catch (error: any) {
       return res.status(500).json({

--- a/src/docs/Orders/order.ts
+++ b/src/docs/Orders/order.ts
@@ -80,6 +80,57 @@ const orderPaths: OpenAPIV3.PathsObject = {
     },
   },
   '/api/orders/': {
+    get: {
+      summary: 'get all user orders',
+      tags: ['Orders'],
+      security: [
+        {
+          bearerAuth: [],
+        },
+      ],
+      description: 'This is the endpoint to get all user orders',
+      responses: {
+        '200': {
+          description: 'successs',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  orders: { type: 'object' },
+                },
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Unauthorized',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  message: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        '500': {
+          description: 'Internal server error',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  message: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     post: {
       summary: 'create an order',
       tags: ['Orders'],

--- a/src/routes/orderRoute.ts
+++ b/src/routes/orderRoute.ts
@@ -10,6 +10,12 @@ router.get(
   authMiddleware.isAuthenticated,
   OrderController.getOrder,
 );
+router.get(
+  '/',
+  authMiddleware.verifyToken,
+  authMiddleware.isAuthenticated,
+  OrderController.getAllUserOrders,
+);
 router.post(
   '/',
   authMiddleware.verifyToken,

--- a/src/tests/orderController.test.ts
+++ b/src/tests/orderController.test.ts
@@ -21,6 +21,7 @@ jest.mock('../database/models', () => ({
     },
     Order: {
       findOne: jest.fn(),
+      findAll: jest.fn(),
       create: jest.fn(),
     },
     OrderProduct: {
@@ -279,7 +280,10 @@ describe('OrderController', () => {
       await OrderController.createOrder(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ order: mockOrder });
+      expect(res.json).toHaveBeenCalledWith({
+        order: mockOrder,
+        paymentIntent: mockPaymentIntent,
+      });
     });
 
     it('should return 500 when stripe error occurs', async () => {
@@ -309,6 +313,50 @@ describe('OrderController', () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({
         message: 'Failed to create order',
+      });
+    });
+  });
+
+  describe('getAllUserOrder', () => {
+    it('should return 200 when all user orders are retrieved', async () => {
+      const req = {
+        user: {
+          userId: mockUser.userId,
+        },
+      } as unknown as Request;
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as unknown as Response;
+
+      db.Order.findAll.mockReturnValue([mockOrder]);
+      await OrderController.getAllUserOrders(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ orders: [mockOrder] });
+    });
+
+    it('should return 500 when error occurs', async () => {
+      const req = {
+        user: {
+          userId: mockUser.userId,
+        },
+      } as unknown as Request;
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as unknown as Response;
+
+      db.Order.findAll.mockImplementation(() => {
+        throw new Error('Database Error');
+      });
+      await OrderController.getAllUserOrders(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Failed to get all user orders',
       });
     });
   });

--- a/src/tests/wishlist.test.ts
+++ b/src/tests/wishlist.test.ts
@@ -2,11 +2,13 @@ import request from 'supertest';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
-import WishlistController from '../controllers/wishlist'; // Adjust the import path accordingly
-import { authenticate } from '../middleware/wishlist'; // Adjust the import path accordingly
-import { db } from '../database/models'; // Adjust the import path accordingly
+import WishlistController from '../controllers/wishlist';
+import { authenticate } from '../middleware/wishlist';
+import { db } from '../database/models';
+
 dotenv.config();
 const secret = process.env.JWT_SECRET as string;
+
 const app = express();
 app.use(express.json());
 app.use(authenticate);
@@ -14,6 +16,7 @@ app.post('/wishlist/:productId', WishlistController.addToWishlist);
 app.delete('/wishlist/:productId', WishlistController.deleteFromWishlist);
 app.get('/wishlist', WishlistController.getWishlist);
 app.delete('/wishlist', WishlistController.clearWishlist);
+
 // Mocking the db models
 jest.mock('../database/models', () => {
   return {
@@ -30,131 +33,170 @@ jest.mock('../database/models', () => {
     },
   };
 });
+
 const token = jwt.sign({ userId: '1' }, secret);
+
 describe('WishlistController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   describe('addToWishlist', () => {
     it('should add a product to the wishlist', async () => {
       db.Product.findOne.mockResolvedValue({ id: '1' });
       db.Wishlist.findOne.mockResolvedValue(null);
       db.Wishlist.create.mockResolvedValue({ userId: '1', productId: '1' });
+
       const res = await request(app)
         .post('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(201);
       expect(res.body.message).toBe('Product added to your wishlist');
     });
+
     it('should return 404 if product not found', async () => {
       db.Product.findOne.mockResolvedValue(null);
+
       const res = await request(app)
         .post('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Product not found');
     });
+
     it('should return 400 if product is already in wishlist', async () => {
       db.Product.findOne.mockResolvedValue({ id: '1' });
       db.Wishlist.findOne.mockResolvedValue({ userId: '1', productId: '1' });
+
       const res = await request(app)
         .post('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(400);
       expect(res.body.message).toBe('Product already in your wishlist');
     });
+
     it('should return 500 if there is an error', async () => {
       db.Product.findOne.mockRejectedValue(
         new Error('Failed to add product to wishlist'),
       );
+
       const res = await request(app)
         .post('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(500);
       expect(res.body.message).toBe('Failed to add product to wishlist');
     });
   });
+
   describe('deleteFromWishlist', () => {
     it('should delete a product from the wishlist', async () => {
       db.Wishlist.findOne.mockResolvedValue({ destroy: jest.fn() });
+
       const res = await request(app)
         .delete('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Product removed from your wishlist');
     });
+
     it('should return 404 if wishlist item not found', async () => {
       db.Wishlist.findOne.mockResolvedValue(null);
+
       const res = await request(app)
         .delete('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(404);
       expect(res.body.message).toBe('Wishlist item not found');
     });
+
     it('should return 500 if there is an error', async () => {
       db.Wishlist.findOne.mockRejectedValue(
         new Error('Failed to remove product from wishlist'),
       );
+
       const res = await request(app)
         .delete('/wishlist/1')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(500);
       expect(res.body.message).toBe('Failed to remove product from wishlist');
     });
   });
+
   describe('getWishlist', () => {
     it('should return the wishlist', async () => {
       db.Wishlist.findAll.mockResolvedValue([
         { productId: '1', product: { name: 'Product 1', price: 100 } },
       ]);
+
       const res = await request(app)
         .get('/wishlist')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(200);
       expect(res.body).toEqual([
         { productId: '1', product: { name: 'Product 1', price: 100 } },
       ]);
     });
+
     it('should return 200 if no items in wishlist', async () => {
       db.Wishlist.findAll.mockResolvedValue([]);
+
       const res = await request(app)
         .get('/wishlist')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(200);
       expect(res.body.message).toBe(undefined);
     });
+
     it('should return 500 if there is an error', async () => {
       db.Wishlist.findAll.mockRejectedValue(
         new Error('Failed to fetch wishlist'),
       );
+
       const res = await request(app)
         .get('/wishlist')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('Failed to fetch wishlist');
     });
   });
+
   describe('clearWishlist', () => {
     it('should clear the wishlist', async () => {
       db.Wishlist.destroy.mockResolvedValue(1);
+
       const res = await request(app)
         .delete('/wishlist')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(200);
       expect(res.body.message).toBe('Wishlist cleared successfully');
     });
+
     it('should return 500 if there is an error', async () => {
       db.Wishlist.destroy.mockRejectedValue(
         new Error('Failed to clear wishlist'),
       );
+
       const res = await request(app)
         .delete('/wishlist')
         .set('Authorization', `Bearer ${token}`);
+
       expect(res.status).toBe(500);
       expect(res.body.message).toBe('Failed to clear wishlist');
     });
   });
 });
+
 describe('authenticate middleware', () => {
   it('should allow access with valid token', async () => {
     const testApp = express();
@@ -162,31 +204,39 @@ describe('authenticate middleware', () => {
     testApp.get('/test', (req, res) =>
       res.status(200).json({ message: 'success' }),
     );
+
     const res = await request(testApp)
       .get('/test')
       .set('Authorization', `Bearer ${token}`);
+
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('success');
   });
+
   it('should deny access with no token', async () => {
     const testApp = express();
     testApp.use(authenticate);
     testApp.get('/test', (req, res) =>
       res.status(200).json({ message: 'success' }),
     );
+
     const res = await request(testApp).get('/test');
+
     expect(res.status).toBe(401);
     expect(res.body.message).toBe('Unauthorized token');
   });
+
   it('should deny access with invalid token', async () => {
     const testApp = express();
     testApp.use(authenticate);
     testApp.get('/test', (req, res) =>
       res.status(200).json({ message: 'success' }),
     );
+
     const res = await request(testApp)
       .get('/test')
       .set('Authorization', 'Bearer invalidtoken');
+
     expect(res.status).toBe(401);
     expect(res.body.error).toBe('Unauthorized');
   });
@@ -195,16 +245,19 @@ describe('WishlistController edge cases', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   describe('addToWishlist', () => {
     it('should return 401 if userId is not present', async () => {
       const testApp = express();
       testApp.use(express.json());
       testApp.post('/wishlist/:productId', WishlistController.addToWishlist);
+
       const res = await request(testApp).post('/wishlist/1');
       expect(res.status).toBe(401);
       expect(res.body.message).toBe('Unauthorized');
     });
   });
+
   describe('deleteFromWishlist', () => {
     it('should return 400 if userId or productId is not present', async () => {
       const testApp = express();
@@ -217,16 +270,19 @@ describe('WishlistController edge cases', () => {
         '/wishlist/:productId',
         WishlistController.deleteFromWishlist,
       );
+
       const res = await request(testApp).delete('/wishlist/');
       expect(res.status).toBe(404);
       expect(res.body.message).toBe(undefined);
     });
   });
+
   describe('clearWishlist', () => {
     it('should return 401 if userId is not present', async () => {
       const testApp = express();
       testApp.use(express.json());
       testApp.delete('/wishlist', WishlistController.clearWishlist);
+
       const res = await request(testApp).delete('/wishlist');
       expect(res.status).toBe(401);
       expect(res.body.message).toBe('Unauthorized');


### PR DESCRIPTION
### What does this bug-fix do

This bug-fix allows the user:

1. to see the paymentIntents Object when a user creates and order
2. to get all orders a user has ever made

### Pull Request fixed:

#59