### PR TITLE
getUser route restricted to admins only

### DIFF
--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -13,7 +13,6 @@ import OrderController from '../controllers/orderController';
 
 const router: Router = express.Router();
 
-router.get('/', UserController.getUsers);
 router.post('/registerUser', UserController.registerUser);
 router.get('/isVerified/:token', UserController.isVerified);
 router.post('/login', UserController.login);


### PR DESCRIPTION
### What does this PR do?

This PR restricts getUser route to users with "admin" role.